### PR TITLE
remove unused launch configuration.

### DIFF
--- a/aws/autoscaling.go
+++ b/aws/autoscaling.go
@@ -18,7 +18,6 @@ type AutoscalingGroupMonitor struct {
 
 type autoscalingGroup struct {
 	autoscalingGroupName string
-	launchConfiguration  string
 	desiredCapacity      int64
 	instanceMonitors     map[string]*InstanceMonitor
 }
@@ -43,7 +42,6 @@ func NewAutoscalingGroupMonitor(awsConnection AwsConnectionInterface, autoscalin
 	return &AutoscalingGroupMonitor{
 		autoscaling: &autoscalingGroup{
 			autoscalingGroupName: autoscalingGroupName,
-			launchConfiguration:  "",
 			desiredCapacity:      0,
 			instanceMonitors:     map[string]*InstanceMonitor{},
 		},
@@ -141,14 +139,13 @@ func (a *AutoscalingGroupMonitor) Refresh(autoscalingGroup *autoscaling.Group) e
 		}
 	}
 
-	a.autoscaling.launchConfiguration = *autoscalingGroup.LaunchConfigurationName
 	a.autoscaling.desiredCapacity = *autoscalingGroup.DesiredCapacity
 
 	for _, instance := range autoscalingGroup.Instances {
 		_, ok := a.autoscaling.instanceMonitors[*instance.InstanceId]
 		if !ok {
 			log.Debugf("Found new instance to monitor in autoscaling %s: %s", a.autoscaling.autoscalingGroupName, *instance.InstanceId)
-			instanceMonitor, _ := NewInstanceMonitor(a.awsConnection, a.autoscaling.autoscalingGroupName, *instance.LaunchConfigurationName, *instance.InstanceId)
+			instanceMonitor, _ := NewInstanceMonitor(a.awsConnection, a.autoscaling.autoscalingGroupName, *instance.InstanceId)
 			a.autoscaling.instanceMonitors[*instance.InstanceId] = instanceMonitor
 		}
 	}

--- a/aws/instance.go
+++ b/aws/instance.go
@@ -21,7 +21,7 @@ type InstanceMonitor struct {
 	awsConnection AwsConnectionInterface
 }
 
-func NewInstanceMonitor(conn AwsConnectionInterface, autoscalingGroupId, launchConfiguration, instanceId string) (*InstanceMonitor, error) {
+func NewInstanceMonitor(conn AwsConnectionInterface, autoscalingGroupId, instanceId string) (*InstanceMonitor, error) {
 
 	response, err := conn.DescribeInstanceById(instanceId)
 
@@ -32,7 +32,6 @@ func NewInstanceMonitor(conn AwsConnectionInterface, autoscalingGroupId, launchC
 	return &InstanceMonitor{
 		instance: &Instance{
 			autoscalingGroupId:  autoscalingGroupId,
-			launchConfiguration: launchConfiguration,
 			ipAddress:           *response.PrivateIpAddress,
 			instanceId:          instanceId,
 			markedToBeRemoved:   isMarkedToBeRemoved(response.Tags),

--- a/aws/instance_test.go
+++ b/aws/instance_test.go
@@ -12,7 +12,7 @@ func TestNewInstanceMonitor(t *testing.T) {
 		},
 	}
 
-	instanceMonitor, _ := NewInstanceMonitor(conn, "autoscalingid", "launchconfid", "i-249b35ae")
+	instanceMonitor, _ := NewInstanceMonitor(conn, "autoscalingid", "i-249b35ae")
 
 	if instanceMonitor == nil {
 		t.Fatal("nil InstanceMonitor")
@@ -35,7 +35,7 @@ func TestTerminateInstance(t *testing.T) {
 		},
 	}
 
-	instanceMonitor, _ := NewInstanceMonitor(conn, "autoscalingid", "launchconfid", "i-249b35ae")
+	instanceMonitor, _ := NewInstanceMonitor(conn, "autoscalingid", "i-249b35ae")
 	instanceMonitor.Destroy()
 
 	callArguments := conn.Requests["TerminateInstance"]
@@ -53,7 +53,7 @@ func TestSetInstanceTag(t *testing.T) {
 		},
 	}
 
-	instanceMonitor, _ := NewInstanceMonitor(conn, "autoscalingid", "launchconfid", "i-249b35ae")
+	instanceMonitor, _ := NewInstanceMonitor(conn, "autoscalingid", "i-249b35ae")
 	instanceMonitor.MarkToBeRemoved()
 
 	callArguments := conn.Requests["SetInstanceTag"]
@@ -75,7 +75,7 @@ func TestInstanceMarkToBeRemoved(t *testing.T) {
 		},
 	}
 
-	instanceMonitor, _ := NewInstanceMonitor(conn, "autoscalingid", "launchconfid", "i-249b35ae")
+	instanceMonitor, _ := NewInstanceMonitor(conn, "autoscalingid", "i-249b35ae")
 
 	if !instanceMonitor.instance.markedToBeRemoved {
 		t.Fatal("wrong markedToBeRemoved value")


### PR DESCRIPTION
It was also crashing as recently created autoscalings might not return launch configuration object