### PR TITLE
make deathnode tag configurable, so we can run multiple deathnodes on…

### DIFF
--- a/aws/autoscaling_test.go
+++ b/aws/autoscaling_test.go
@@ -14,7 +14,7 @@ func TestNewAutoscalingGroupMonitor(t *testing.T) {
 	}
 
 	autoscalingGroupNames := []string{"some-Autoscaling-Group"}
-	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames)
+	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames, "DEATH_NODE_MARK")
 	autoscalingGroups.Refresh()
 	monitor := autoscalingGroups.GetMonitors()[0]
 
@@ -45,7 +45,7 @@ func TestNumUndesiredASGinstances(t *testing.T) {
 	}
 
 	autoscalingGroupNames := []string{"some-Autoscaling-Group"}
-	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames)
+	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames, "DEATH_NODE_MARK")
 	autoscalingGroups.Refresh()
 	monitor := autoscalingGroups.GetMonitors()[0]
 
@@ -64,7 +64,7 @@ func TestNewAutoscalingGroups(t *testing.T) {
 	}
 
 	autoscalingGroupNames := []string{"some-Autoscaling-Group"}
-	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames)
+	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames, "DEATH_NODE_MARK")
 	autoscalingGroups.Refresh()
 
 	if (autoscalingGroups.GetMonitors())[0].autoscaling.autoscalingGroupName != "some-Autoscaling-Group" {
@@ -82,7 +82,7 @@ func TestRefresh(t *testing.T) {
 	}
 
 	autoscalingGroupNames := []string{"some-Autoscaling-Group"}
-	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames)
+	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames, "DEATH_NODE_MARK")
 	autoscalingGroups.Refresh()
 
 	autoscalingGroup := (autoscalingGroups.GetMonitors())[0]
@@ -116,7 +116,7 @@ func TestSetInstanceProtection(t *testing.T) {
 	}
 
 	autoscalingGroupNames := []string{"some-Autoscaling-Group"}
-	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames)
+	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames, "DEATH_NODE_MARK")
 	autoscalingGroups.Refresh()
 
 	callArguments := awsConn.Requests["SetASGInstanceProtection"]
@@ -151,7 +151,7 @@ func TestTwoAutoscalingMonitors(t *testing.T) {
 	}
 
 	autoscalingGroupNames := []string{"some-Autoscaling-Group"}
-	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames)
+	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames, "DEATH_NODE_MARK")
 	autoscalingGroups.Refresh()
 	autoscalingGroups.Refresh()
 	monitors := autoscalingGroups.GetMonitors()
@@ -189,7 +189,7 @@ func TestRemoveAutoscalingGroup(t *testing.T) {
 	}
 
 	autoscalingGroupNames := []string{"some-Autoscaling-Group"}
-	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames)
+	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames, "DEATH_NODE_MARK")
 	autoscalingGroups.Refresh()
 	autoscalingGroups.Refresh()
 	autoscalingGroups.Refresh()
@@ -210,7 +210,7 @@ func TestGetAutoscalingNameByInstanceId(t *testing.T) {
 	}
 
 	autoscalingGroupNames := []string{"some-Autoscaling-Group"}
-	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames)
+	autoscalingGroups, _ := NewAutoscalingGroups(awsConn, autoscalingGroupNames, "DEATH_NODE_MARK")
 	autoscalingGroups.Refresh()
 
 	asgID, _ := autoscalingGroups.GetAutoscalingNameByInstanceID("i-34719eb8")

--- a/aws/instance_test.go
+++ b/aws/instance_test.go
@@ -12,7 +12,7 @@ func TestNewInstanceMonitor(t *testing.T) {
 		},
 	}
 
-	instanceMonitor, _ := newInstanceMonitor(conn, "autoscalingid", "i-249b35ae")
+	instanceMonitor, _ := newInstanceMonitor(conn, "autoscalingid", "i-249b35ae", "DEATH_NODE_MARK")
 
 	if instanceMonitor == nil {
 		t.Fatal("nil InstanceMonitor")
@@ -35,12 +35,12 @@ func TestSetInstanceTag(t *testing.T) {
 		},
 	}
 
-	instanceMonitor, _ := newInstanceMonitor(conn, "autoscalingid", "i-249b35ae")
+	instanceMonitor, _ := newInstanceMonitor(conn, "autoscalingid", "i-249b35ae", "DEATH_NODE_MARK")
 	instanceMonitor.MarkToBeRemoved()
 
 	callArguments := conn.Requests["SetInstanceTag"]
 
-	if (callArguments)[0][0] != DeathNodeTagMark {
+	if (callArguments)[0][0] != "DEATH_NODE_MARK" {
 		t.Fatal("Incorrect tag key for SetTags")
 	}
 
@@ -57,7 +57,7 @@ func TestInstanceMarkToBeRemoved(t *testing.T) {
 		},
 	}
 
-	instanceMonitor, _ := newInstanceMonitor(conn, "autoscalingid", "i-249b35ae")
+	instanceMonitor, _ := newInstanceMonitor(conn, "autoscalingid", "i-249b35ae", "DEATH_NODE_MARK")
 
 	if !instanceMonitor.instance.markedToBeRemoved {
 		t.Fatal("wrong markedToBeRemoved value")

--- a/deathnode/notebook.go
+++ b/deathnode/notebook.go
@@ -18,10 +18,11 @@ type Notebook struct {
 	autoscalingGroups   *aws.AutoscalingGroups
 	delayDeleteSeconds  int
 	lastDeleteTimestamp time.Time
+	deathNodeMark       string
 }
 
 // NewNotebook creates a notebook object, which is in charge of monitoring and delete instances marked to be deleted
-func NewNotebook(autoscalingGroups *aws.AutoscalingGroups, awsConn aws.ClientInterface, mesosMonitor *mesos.Monitor, delayDeleteSeconds int) *Notebook {
+func NewNotebook(autoscalingGroups *aws.AutoscalingGroups, awsConn aws.ClientInterface, mesosMonitor *mesos.Monitor, delayDeleteSeconds int, deathNodeMark string) *Notebook {
 
 	return &Notebook{
 		mesosMonitor:        mesosMonitor,
@@ -29,6 +30,7 @@ func NewNotebook(autoscalingGroups *aws.AutoscalingGroups, awsConn aws.ClientInt
 		autoscalingGroups:   autoscalingGroups,
 		delayDeleteSeconds:  delayDeleteSeconds,
 		lastDeleteTimestamp: time.Time{},
+		deathNodeMark:       deathNodeMark,
 	}
 }
 
@@ -49,9 +51,9 @@ func (n *Notebook) setAgentsInMaintenance(instances []*ec2.Instance) error {
 func (n *Notebook) DestroyInstancesAttempt() error {
 
 	// Get instances marked for removal
-	instances, err := n.awsConnection.DescribeInstancesByTag(aws.DeathNodeTagMark)
+	instances, err := n.awsConnection.DescribeInstancesByTag(n.deathNodeMark)
 	if err != nil {
-		log.Debugf("Unable to find instances with %s tag", aws.DeathNodeTagMark)
+		log.Debugf("Unable to find instances with %s tag", n.deathNodeMark)
 		return err
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -261,8 +261,8 @@ func prepareRunParameters(awsConn aws.ClientInterface, mesosConn mesos.ClientInt
 	recommenderType := "smallestInstanceId"
 
 	mesosMonitor := mesos.NewMonitor(mesosConn, protectedFrameworks)
-	autoscalingGroups, _ := aws.NewAutoscalingGroups(awsConn, autoscalingGroupsNames)
-	notebook := deathnode.NewNotebook(autoscalingGroups, awsConn, mesosMonitor, delayDeleteSeconds)
+	autoscalingGroups, _ := aws.NewAutoscalingGroups(awsConn, autoscalingGroupsNames, "DEATH_NODE_MARK")
+	notebook := deathnode.NewNotebook(autoscalingGroups, awsConn, mesosMonitor, delayDeleteSeconds, "DEATH_NODE_MARK")
 	deathNodeWatcher := deathnode.NewWatcher(notebook, mesosMonitor, constraintsType, recommenderType)
 	return mesosMonitor, autoscalingGroups, deathNodeWatcher, notebook
 }


### PR DESCRIPTION
… multiple clusters in the same account.

In a close future, move most of those configurations into a context object