### PR TITLE
Fix crash when no instance information found

### DIFF
--- a/aws/autoscaling.go
+++ b/aws/autoscaling.go
@@ -157,7 +157,11 @@ func (a *AutoscalingGroupMonitor) refresh(autoscalingGroup *autoscaling.Group) e
 		_, ok := a.autoscaling.instanceMonitors[*instance.InstanceId]
 		if !ok {
 			log.Debugf("Found new instance to monitor in autoscaling %s: %s", a.autoscaling.autoscalingGroupName, *instance.InstanceId)
-			instanceMonitor, _ := newInstanceMonitor(a.awsConnection, a.autoscaling.autoscalingGroupName, *instance.InstanceId, a.deathNodeMark)
+			instanceMonitor, err := newInstanceMonitor(a.awsConnection, a.autoscaling.autoscalingGroupName, *instance.InstanceId, a.deathNodeMark)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
 			a.autoscaling.instanceMonitors[*instance.InstanceId] = instanceMonitor
 		}
 	}

--- a/aws/client.go
+++ b/aws/client.go
@@ -129,6 +129,10 @@ func (c *Client) DescribeInstanceByID(instanceID string) (*ec2.Instance, error) 
 		return nil, err
 	}
 
+	if len(response.Reservations) < 1 || len(response.Reservations[0].Instances) < 1 {
+		return nil, fmt.Errorf("No instance information found for instance id %v", instanceID)
+	}
+
 	return response.Reservations[0].Instances[0], nil
 }
 


### PR DESCRIPTION
Seems like aws autoscaling group might return that still has some instances
that doesn't exist in aws anymore. The call against aws was expecting that
the information (if the call succeded) would always exist. Fix it to handle
the case when it doesn't