### PR TITLE
Add label protection for running applications

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -11,11 +11,10 @@ import (
 )
 
 const (
-	lifecycleHookName = "DEATHNODE"
-	continueString = "CONTINUE"
+	lifecycleHookName                   = "DEATHNODE"
+	continueString                      = "CONTINUE"
 	lifecycleTransitionTerminationState = "autoscaling:EC2_INSTANCE_TERMINATING"
 )
-
 
 // Client holds the AWS SDK objects for call AWS API
 type Client struct {
@@ -47,7 +46,6 @@ func NewClient(accessKey, secretKey, region, iamRole, iamSession string) (*Clien
 		iamSession: iamSession,
 	})
 
-
 	if err != nil {
 		fmt.Print("Error trying to create AWS session. ", err)
 	}
@@ -59,13 +57,13 @@ func NewClient(accessKey, secretKey, region, iamRole, iamSession string) (*Clien
 }
 
 // CompleteLifecycleAction completes a lifecycle event for an instance pending to be deleted
-func (c* Client) CompleteLifecycleAction(autoscalingGroupName, instanceID *string) error {
+func (c *Client) CompleteLifecycleAction(autoscalingGroupName, instanceID *string) error {
 
-	completeLifecycleActionInput := &autoscaling.CompleteLifecycleActionInput {
-		AutoScalingGroupName: autoscalingGroupName,
-		InstanceId: instanceID,
+	completeLifecycleActionInput := &autoscaling.CompleteLifecycleActionInput{
+		AutoScalingGroupName:  autoscalingGroupName,
+		InstanceId:            instanceID,
 		LifecycleActionResult: aws.String(continueString),
-		LifecycleHookName: aws.String(lifecycleHookName),
+		LifecycleHookName:     aws.String(lifecycleHookName),
 	}
 
 	_, err := c.autoscaling.CompleteLifecycleAction(completeLifecycleActionInput)
@@ -77,7 +75,7 @@ func (c *Client) HasLifeCycleHook(autoscalingGroupName *string) (bool, error) {
 
 	describeLifecycleHooksInput := &autoscaling.DescribeLifecycleHooksInput{
 		AutoScalingGroupName: autoscalingGroupName,
-		LifecycleHookNames: []*string{aws.String(lifecycleHookName)},
+		LifecycleHookNames:   []*string{aws.String(lifecycleHookName)},
 	}
 
 	describeLifecycleHooksOutput, err := c.autoscaling.DescribeLifecycleHooks(describeLifecycleHooksInput)
@@ -93,10 +91,10 @@ func (c *Client) PutLifeCycleHook(autoscalingGroupName *string, heartbeatTimeout
 
 	putLifecycleHookInput := &autoscaling.PutLifecycleHookInput{
 		AutoScalingGroupName: autoscalingGroupName,
-		DefaultResult: aws.String(continueString),
-		HeartbeatTimeout: heartbeatTimeout,
-		LifecycleHookName: aws.String(lifecycleHookName),
-		LifecycleTransition: aws.String(lifecycleTransitionTerminationState),
+		DefaultResult:        aws.String(continueString),
+		HeartbeatTimeout:     heartbeatTimeout,
+		LifecycleHookName:    aws.String(lifecycleHookName),
+		LifecycleTransition:  aws.String(lifecycleTransitionTerminationState),
 	}
 
 	_, err := c.autoscaling.PutLifecycleHook(putLifecycleHookInput)

--- a/aws/client_mock.go
+++ b/aws/client_mock.go
@@ -90,13 +90,13 @@ func (c *ConnectionMock) PutLifeCycleHook(autoscalingGroupName *string, heartbea
 }
 
 // CompleteLifecycleAction is a mock call for testing purposes
-func (c* ConnectionMock) CompleteLifecycleAction(autoscalingGroupName, instanceID *string) error {
+func (c *ConnectionMock) CompleteLifecycleAction(autoscalingGroupName, instanceID *string) error {
 
 	c.addRequests("CompleteLifecycleAction", []string{*autoscalingGroupName, *instanceID})
 	return nil
 }
 
-func (c* ConnectionMock) addRequests(funcName string, parameters []string) {
+func (c *ConnectionMock) addRequests(funcName string, parameters []string) {
 
 	if c.Requests == nil {
 		c.Requests = map[string][][]string{}

--- a/deathnode/constraints.go
+++ b/deathnode/constraints.go
@@ -12,7 +12,7 @@ func newConstraint(constraintType string) (constraint, error) {
 	case "noContraint":
 		return &noConstraint{}, nil
 	default:
-		return nil, fmt.Errorf("Contraint type %v not found", constraintType)
+		return nil, fmt.Errorf("Constraint type %v not found", constraintType)
 	}
 }
 

--- a/deathnode/constraints_test.go
+++ b/deathnode/constraints_test.go
@@ -1,10 +1,10 @@
 package deathnode
 
 import (
-	"testing"
 	"github.com/alanbover/deathnode/aws"
 	"github.com/alanbover/deathnode/monitor"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestConstraints(t *testing.T) {

--- a/deathnode/notebook.go
+++ b/deathnode/notebook.go
@@ -78,9 +78,10 @@ func (n *Notebook) DestroyInstancesAttempt() error {
 			continue
 		}
 
-		// If the instance have no tasks from protected frameworks, delete it
-		hasFrameworks := n.mesosMonitor.HasProtectedFrameworksTasks(*instance.PrivateIpAddress)
-		if !hasFrameworks {
+		// If the instance can be killed, delete it
+		isProtected := n.mesosMonitor.IsProtected(*instance.PrivateIpAddress)
+
+		if !isProtected {
 			if instanceMonitor.GetLifecycleState() == "Terminating:Wait" {
 				log.Infof("Destroy instance %s", *instanceMonitor.GetInstanceID())
 				err := n.awsConnection.CompleteLifecycleAction(instanceMonitor.GetAutoscalingGroupID(), instanceMonitor.GetInstanceID())
@@ -94,8 +95,6 @@ func (n *Notebook) DestroyInstancesAttempt() error {
 			} else {
 				log.Debugf("Instance %s waiting for AWS to start termination lifecycle", *instance.InstanceId)
 			}
-		} else {
-			log.Debugf("Instance %s can't be deleted. It contains tasks from protected frameworks", *instance.InstanceId)
 		}
 	}
 

--- a/deathnode/notebook_test.go
+++ b/deathnode/notebook_test.go
@@ -2,10 +2,10 @@ package deathnode
 
 import (
 	"github.com/alanbover/deathnode/aws"
-	"testing"
-	"github.com/alanbover/deathnode/monitor"
 	"github.com/alanbover/deathnode/mesos"
+	"github.com/alanbover/deathnode/monitor"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestDestroyInstanceAttempt(t *testing.T) {
@@ -42,7 +42,7 @@ func TestDestroyInstanceAttempt(t *testing.T) {
 		})
 		Convey("if there is a instance marked to be removed", func() {
 			awsConn.Records = map[string]*[]string{
-				"DescribeInstancesByTag":       {"one_undesired_host", "one_undesired_host"},
+				"DescribeInstancesByTag": {"one_undesired_host", "one_undesired_host"},
 			}
 			instanceMonitor, _ := notebook.autoscalingGroups.GetInstanceByID("i-34719eb8")
 			Convey("Check remove instance protection flags", func() {
@@ -128,8 +128,9 @@ func TestDestroyInstanceAttempt(t *testing.T) {
 func newNotebook(awsConn aws.ClientInterface, mesosConn mesos.ClientInterface, delayDeleteSeconds int) *Notebook {
 
 	protectedFrameworks := []string{"frameworkName1"}
+	protectedTasksLabels := []string{"task1"}
 	autoscalingGroupsNames := []string{"some-Autoscaling-Group"}
-	mesosMonitor := monitor.NewMesosMonitor(mesosConn, protectedFrameworks)
+	mesosMonitor := monitor.NewMesosMonitor(mesosConn, protectedFrameworks, protectedTasksLabels)
 	autoscalingGroups, _ := monitor.NewAutoscalingGroupMonitors(awsConn, autoscalingGroupsNames, "DEATH_NODE_MARK")
 
 	mesosMonitor.Refresh()

--- a/deathnode/recommender_test.go
+++ b/deathnode/recommender_test.go
@@ -1,9 +1,9 @@
 package deathnode
 
 import (
-	"testing"
 	"github.com/alanbover/deathnode/aws"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestRecommender(t *testing.T) {

--- a/deathnode/watcher.go
+++ b/deathnode/watcher.go
@@ -30,10 +30,10 @@ func NewWatcher(notebook *Notebook, mesosMonitor *monitor.MesosMonitor, autoscal
 	}
 
 	return &Watcher{
-		notebook:     notebook,
-		mesosMonitor: mesosMonitor,
-		constraints:  contrainsts,
-		recommender:  recommender,
+		notebook:          notebook,
+		mesosMonitor:      mesosMonitor,
+		constraints:       contrainsts,
+		recommender:       recommender,
 		autoscalingGroups: autoscalingGroups,
 	}
 }

--- a/deathnode/watcher_test.go
+++ b/deathnode/watcher_test.go
@@ -2,8 +2,8 @@ package deathnode
 
 import (
 	"github.com/alanbover/deathnode/aws"
-	"github.com/alanbover/deathnode/monitor"
 	"github.com/alanbover/deathnode/mesos"
+	"github.com/alanbover/deathnode/monitor"
 	log "github.com/sirupsen/logrus"
 	"testing"
 	"time"
@@ -154,7 +154,7 @@ func TestInstanceDeleteIfDelayDeleteIsSet(t *testing.T) {
 			},
 			"DescribeInstancesByTag": {"default", "two_undesired_hosts",
 				"two_undesired_hosts", "two_undesired_hosts", "two_undesired_hosts"},
-			"DescribeAGByName":       {"default", "two_undesired_hosts", "two_undesired_hosts_two_terminating",
+			"DescribeAGByName": {"default", "two_undesired_hosts", "two_undesired_hosts_two_terminating",
 				"two_undesired_hosts_two_terminating", "two_undesired_hosts_two_terminating"},
 		},
 	}
@@ -251,12 +251,13 @@ func TestNoInstancesBeingRemovedFromASG(t *testing.T) {
 func newWatcher(awsConn aws.ClientInterface, mesosConn mesos.ClientInterface, delayDeleteSeconds int) *Watcher {
 
 	protectedFrameworks := []string{"frameworkName1"}
+	protectedTasksLabels := []string{"DEATHNODE_PROTECTED"}
 	autoscalingGroupsNames := []string{"some-Autoscaling-Group"}
 
 	constraintsType := "noContraint"
 	recommenderType := "smallestInstanceId"
 
-	mesosMonitor := monitor.NewMesosMonitor(mesosConn, protectedFrameworks)
+	mesosMonitor := monitor.NewMesosMonitor(mesosConn, protectedFrameworks, protectedTasksLabels)
 	autoscalingGroups, _ := monitor.NewAutoscalingGroupMonitors(awsConn, autoscalingGroupsNames, "DEATH_NODE_MARK")
 	notebook := NewNotebook(autoscalingGroups, awsConn, mesosMonitor, delayDeleteSeconds, "DEATH_NODE_MARK")
 	deathNodeWatcher := NewWatcher(notebook, mesosMonitor, autoscalingGroups, constraintsType, recommenderType)

--- a/main.go
+++ b/main.go
@@ -5,16 +5,16 @@ import "flag"
 
 import (
 	"github.com/alanbover/deathnode/aws"
-	"github.com/alanbover/deathnode/monitor"
 	"github.com/alanbover/deathnode/deathnode"
 	"github.com/alanbover/deathnode/mesos"
+	"github.com/alanbover/deathnode/monitor"
 	log "github.com/sirupsen/logrus"
 )
 
 type arrayFlags []string
 
 var accessKey, secretKey, region, iamRole, iamSession, mesosURL, constraintsType, recommenderType, deathNodeMark string
-var autoscalingGroupPrefixes, protectedFrameworks arrayFlags
+var autoscalingGroupPrefixes, protectedFrameworks, protectedTasksLabels arrayFlags
 var pollingSeconds, delayDeleteSeconds int
 var debug bool
 
@@ -39,7 +39,7 @@ func main() {
 	mesosConn := &mesos.Client{
 		MasterURL: mesosURL,
 	}
-	mesosMonitor := monitor.NewMesosMonitor(mesosConn, protectedFrameworks)
+	mesosMonitor := monitor.NewMesosMonitor(mesosConn, protectedFrameworks, protectedTasksLabels)
 
 	// Create deathnoteWatcher
 	notebook := deathnode.NewNotebook(autoscalingGroups, awsConn, mesosMonitor, delayDeleteSeconds, deathNodeMark)
@@ -52,29 +52,28 @@ func main() {
 	}
 }
 
-
 func initFlags() {
 
-	flag.StringVar(&accessKey, "accessKey", "", "help message for flagname")
-	flag.StringVar(&secretKey, "secretKey", "", "help message for flagname")
-	flag.StringVar(&region, "region", "eu-west-1", "help message for flagname")
-	flag.StringVar(&iamRole, "iamRole", "", "help message for flagname")
-	flag.StringVar(&iamSession, "iamSession", "", "help message for flagname")
+	flag.StringVar(&accessKey, "accessKey", "", "AWS_ACCESS_KEY_ID.")
+	flag.StringVar(&secretKey, "secretKey", "", "AWS_SECRET_ACCESS_KEY.")
+	flag.StringVar(&region, "region", "eu-west-1", "AWS_REGION.")
+	flag.StringVar(&iamRole, "iamRole", "", "IAMROLE to assume.")
+	flag.StringVar(&iamSession, "iamSession", "", "Session for IAMROLE.")
 
-	flag.BoolVar(&debug, "debug", false, "Enable debug logging")
-	flag.StringVar(&mesosURL, "mesosUrl", "", "The URL for Mesos master")
+	flag.BoolVar(&debug, "debug", false, "Enable debug logging.")
+	flag.StringVar(&mesosURL, "mesosUrl", "", "The URL for Mesos master.")
 
-	flag.Var(&autoscalingGroupPrefixes, "autoscalingGroupName", "An autoscalingGroup prefix for monitor")
-	flag.Var(&protectedFrameworks, "protectedFrameworks", "The mesos frameworks to wait for kill the node")
-
+	flag.Var(&autoscalingGroupPrefixes, "autoscalingGroupName", "An autoscalingGroup prefix for monitor.")
+	flag.Var(&protectedFrameworks, "protectedFrameworks", "The mesos frameworks to wait for kill the node.")
+	flag.Var(&protectedTasksLabels, "protectedTaskLabels", "The labels used for protected tasks.")
 	// Move constraints to array, so we apply multiple
-	flag.StringVar(&constraintsType, "constraintsType", "noContraint", "The constrainst implementation to use")
-	flag.StringVar(&recommenderType, "recommenderType", "firstAvailableAgent", "The recommender implementation to use")
+	flag.StringVar(&constraintsType, "constraintsType", "noContraint", "The constrainst implementation to use.")
+	flag.StringVar(&recommenderType, "recommenderType", "firstAvailableAgent", "The recommender implementation to use.")
 
-	flag.StringVar(&deathNodeMark, "deathNodeMark", "DEATH_NODE_MARK", "The tag to apply for instances to be deleted")
+	flag.StringVar(&deathNodeMark, "deathNodeMark", "DEATH_NODE_MARK", "The tag to apply for instances to be deleted.")
 
-	flag.IntVar(&pollingSeconds, "polling", 60, "Seconds between executions")
-	flag.IntVar(&delayDeleteSeconds, "delayDelete", 0, "Time to wait between kill executions (in seconds)")
+	flag.IntVar(&pollingSeconds, "polling", 60, "Seconds between executions.")
+	flag.IntVar(&delayDeleteSeconds, "delayDelete", 0, "Time to wait between kill executions (in seconds).")
 
 	flag.Parse()
 }

--- a/mesos/client.go
+++ b/mesos/client.go
@@ -58,6 +58,14 @@ type Task struct {
 	SlaveID     string   `json:"slave_id"`
 	FrameworkID string   `json:"framework_id"`
 	Statuses    []Status `json:"statuses"`
+	Labels      []Labels `json:"labels"`
+	IsProtected bool
+}
+
+// Labels is part of the mesos tasks response API endpoint
+type Labels struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // Status is part of the mesos tasks response API endpoint

--- a/mesos/testdata/default/GetMesosTasks.json
+++ b/mesos/testdata/default/GetMesosTasks.json
@@ -10,6 +10,12 @@
           "state": "TASK_RUNNING",
           "timestamp": 123456.786543
         }
+      ],
+      "labels": [
+        {
+          "key":"DEATHNODE_PROTECTED",
+          "value":"true"
+        }
       ]
     },
     {
@@ -21,6 +27,12 @@
         {
           "state": "TASK_RUNNING",
           "timestamp": 123456.786543
+        }
+      ],
+      "labels": [
+        {
+          "key":"DEATHNODE_PROTECTED",
+          "value":"false"
         }
       ]
     },

--- a/monitor/autoscaling.go
+++ b/monitor/autoscaling.go
@@ -1,10 +1,10 @@
 package monitor
 
 import (
-	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/alanbover/deathnode/aws"
-	log "github.com/sirupsen/logrus"
 	"fmt"
+	"github.com/alanbover/deathnode/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	log "github.com/sirupsen/logrus"
 )
 
 // AutoscalingGroupsMonitor holds a map of [ASGprefix][ASGname]AutoscalingGroupMonitor

--- a/monitor/autoscaling_test.go
+++ b/monitor/autoscaling_test.go
@@ -1,9 +1,9 @@
 package monitor
 
 import (
-	"testing"
 	"github.com/alanbover/deathnode/aws"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestNewAutoscalingGroup(t *testing.T) {
@@ -70,7 +70,7 @@ func TestRefresh(t *testing.T) {
 				Records: map[string]*[]string{
 					"DescribeInstanceById": {
 						"default", "default", "default", "default", "default", "default"},
-					"DescribeAGByName":     {"default", "refresh"},
+					"DescribeAGByName": {"default", "refresh"},
 				},
 			})
 			monitors.Refresh()
@@ -196,7 +196,6 @@ func TestGetInstanceById(t *testing.T) {
 		})
 	})
 }
-
 
 func newTestMonitor(awsConn *aws.ConnectionMock) *AutoscalingGroupMonitor {
 

--- a/monitor/instance.go
+++ b/monitor/instance.go
@@ -2,8 +2,8 @@ package monitor
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/alanbover/deathnode/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"time"
 )
 
@@ -34,12 +34,12 @@ func newInstanceMonitor(conn aws.ClientInterface, autoscalingGroupID, instanceID
 
 	return &InstanceMonitor{
 		instance: &instance{
-			autoscalingGroupID:   autoscalingGroupID,
-			ipAddress:            *response.PrivateIpAddress,
-			instanceID:           instanceID,
-			isMarkedToBeRemoved:  isMarkedToBeRemoved(response.Tags, deathNodeMark),
-			lifecycleState:       lifecycleState,
-			isProtected:	      isProtected,
+			autoscalingGroupID:  autoscalingGroupID,
+			ipAddress:           *response.PrivateIpAddress,
+			instanceID:          instanceID,
+			isMarkedToBeRemoved: isMarkedToBeRemoved(response.Tags, deathNodeMark),
+			lifecycleState:      lifecycleState,
+			isProtected:         isProtected,
 		},
 		awsConnection: conn,
 		deathNodeMark: deathNodeMark,
@@ -67,7 +67,7 @@ func (a *InstanceMonitor) GetAutoscalingGroupID() *string {
 }
 
 // RemoveInstanceProtection removes the instance protection for the autoscaling
-func (a* InstanceMonitor) RemoveInstanceProtection() error {
+func (a *InstanceMonitor) RemoveInstanceProtection() error {
 	err := a.awsConnection.RemoveASGInstanceProtection(&a.instance.autoscalingGroupID, []*string{&a.instance.instanceID})
 	if err != nil {
 		return err

--- a/monitor/instance_test.go
+++ b/monitor/instance_test.go
@@ -1,9 +1,9 @@
 package monitor
 
 import (
-	"testing"
 	"github.com/alanbover/deathnode/aws"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestNewInstanceMonitor(t *testing.T) {


### PR DESCRIPTION
![](https://media.giphy.com/media/pzPMsjDenwlEc/giphy.gif)
-Labels like DEATHNODE_PROTECTED=true prevent the agent to be elected to kill.